### PR TITLE
Fix backend-frontend communication

### DIFF
--- a/src/klee_web/frontend/realtime.py
+++ b/src/klee_web/frontend/realtime.py
@@ -9,4 +9,4 @@ pusher = pusher.Pusher(
 
 
 def send_notification(channel, notification_type, data):
-    pusher[channel].trigger(notification_type, {'data': data})
+    pusher.trigger(channel, notification_type, {'data': data})

--- a/src/klee_web/settings.py
+++ b/src/klee_web/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 import os
 import sys
 import django.conf.global_settings as global_settings
+from time import gmtime, strftime
+
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -87,6 +89,8 @@ DATABASES = {
 # https://docs.djangoproject.com/en/1.7/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = strftime("%Z", gmtime()) 
 
 USE_I18N = True
 


### PR DESCRIPTION
Klee outcome are now displayed on the website (was failing due to a deprecated call to Pusher's trigger function). Added Django timezone settings.
