### PR TITLE
Remove some keys from development

### DIFF
--- a/provisioning/roles/common/tasks/deploy.yml
+++ b/provisioning/roles/common/tasks/deploy.yml
@@ -1,7 +1,12 @@
 ---
 
 - name: Copying environment variable file
-  template: src=environment.j2 dest=/etc/profile.d/klee-web-environment.sh
+  template: src=environment_dev.j2 dest=/etc/profile.d/klee-web-environment.sh
+  when: development
+
+- name: Copying production only variable file
+  template: src=environment_prod.j2 dest=/etc/profile.d/klee-web-environment.sh
+  when: not development
 
 - name: Clone TITB code
   git: repo={{ git_repo }} dest={{ src_dir }} accept_hostkey=yes

--- a/provisioning/roles/common/templates/environment_dev.j2
+++ b/provisioning/roles/common/templates/environment_dev.j2
@@ -4,8 +4,6 @@ export REDIS_PORT={{ redis_port }}
 
 export CELERY_BROKER_URL={{ celery_broker_url }}
 
-export DJANGO_SECRET_KEY="{{ django_secret_key }}"
-
 export PUSHER_KEY={{ pusher_key }}
 export PUSHER_SECRET={{ pusher_secret }}
 

--- a/provisioning/roles/common/templates/environment_dev.j2
+++ b/provisioning/roles/common/templates/environment_dev.j2
@@ -4,10 +4,6 @@ export REDIS_PORT={{ redis_port }}
 
 export CELERY_BROKER_URL={{ celery_broker_url }}
 
-export AWS_ACCESS_KEY={{ aws_access_key }}
-export AWS_SECRET_KEY={{ aws_secret_key }}
-
-export MAILGUN_API_KEY={{ mailgun_api_key }}
 export DJANGO_SECRET_KEY="{{ django_secret_key }}"
 
 export PUSHER_KEY={{ pusher_key }}
@@ -18,5 +14,4 @@ export DB_PASSWORD={{ db_password }}
 export DB_HOST={{ db_host }}
 export DB_PORT={{ db_port }}
 export DB_NAME={{ db_name }}
-
-{{ "export DEVELOPMENT=1" if development else "" }}
+export DEVELOPMENT=1

--- a/provisioning/roles/common/templates/environment_prod.j2
+++ b/provisioning/roles/common/templates/environment_prod.j2
@@ -1,0 +1,20 @@
+export REDIS_HOST={{ redis_host }}
+export REDIS_DB_NUMBER={{ redis_db_number }}
+export REDIS_PORT={{ redis_port }}
+
+export CELERY_BROKER_URL={{ celery_broker_url }}
+
+export AWS_ACCESS_KEY={{ aws_access_key }}
+export AWS_SECRET_KEY={{ aws_secret_key }}
+
+export MAILGUN_API_KEY={{ mailgun_api_key }}
+export DJANGO_SECRET_KEY="{{ django_secret_key }}"
+
+export PUSHER_KEY={{ pusher_key }}
+export PUSHER_SECRET={{ pusher_secret }}
+
+export DB_USER={{ db_user }}
+export DB_PASSWORD={{ db_password }}
+export DB_HOST={{ db_host }}
+export DB_PORT={{ db_port }}
+export DB_NAME={{ db_name }}

--- a/src/klee_web/settings.py
+++ b/src/klee_web/settings.py
@@ -14,6 +14,8 @@ import sys
 import django.conf.global_settings as global_settings
 from time import gmtime, strftime
 
+import string
+import random
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -24,12 +26,16 @@ sys.path.insert(0, os.path.join(BASE_DIR, ".."))
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEVELOPMENT") is not None
 
-TEMPLATE_DEBUG = os.environ.get("DEVELOPMENT") is not None
+# If we're in debug mode, generate a random key so that we don't need to provide one
+key = ''.join([random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(50)]) if DEBUG else ''
+SECRET_KEY = key if DEBUG else os.environ.get("DJANGO_SECRET_KEY")
+
+TEMPLATE_DEBUG = DEBUG
 
 ALLOWED_HOSTS = ['*']
 

--- a/src/klee_web/worker/mailer/dummy_mailer.py
+++ b/src/klee_web/worker/mailer/dummy_mailer.py
@@ -1,0 +1,7 @@
+import os
+class DummyMailer():
+    def __init__(self, api_key=None):
+      pass
+
+    def send_mail(self, recipient, subject, email_body):
+      pass 

--- a/src/klee_web/worker/runner.py
+++ b/src/klee_web/worker/runner.py
@@ -12,6 +12,7 @@ from decorators import notify_on_entry
 from worker_config import WorkerConfig
 
 from mailer.mailgun_mailer import MailgunMailer
+from mailer.dummy_mailer import DummyMailer
 
 from processor.failed_test import FailedTestProcessor
 from processor.coverage import CoverageProcessor
@@ -21,6 +22,7 @@ from processor.stats import StatsProcessor
 
 ANSI_ESCAPE_PATTERN = re.compile(r'\x1b[^m]*m')
 LXC_MESSAGE_PATTERN = re.compile(r'lxc-start: .*')
+DEVELOPMENT = os.environ.get('DEVELOPMENT') is not None
 
 worker_config = WorkerConfig()
 
@@ -38,7 +40,7 @@ class WorkerRunner():
     def __init__(self, task_id, callback_endpoint=None, pipeline=None):
         self.task_id = task_id
         self.callback_endpoint = callback_endpoint
-        self.mailer = MailgunMailer()
+        self.mailer = DummyMailer() if DEVELOPMENT else MailgunMailer()
         self.pipeline = pipeline or WorkerRunner.DEFAULT_PROCESSOR_PIPELINE
 
     def __enter__(self):


### PR DESCRIPTION
- Create a DummyMailer so that in development mode Mailgun is not used
- Generate a random Django secret key when in development
- Create a separate env file for development mode where some secret keys are not set.
  Given that we can remove every other secret key, this allows us to use the vault file only in production mode

List of keys removed:
- Mailgun
- Django
- AWS
