### PR TITLE
Provisioning: Switch to PostgreSQL 9.5

### DIFF
--- a/provisioning/roles/db/tasks/main.yml
+++ b/provisioning/roles/db/tasks/main.yml
@@ -1,19 +1,29 @@
 ---
 
+- name: "Add postgresql repo"
+  template: src=pgdg.list dest=/etc/apt/sources.list.d/pgdg.list
+  when: not ci
+  tags: packages
+
+- name: "Add postgresql key"
+  shell: wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+  when: not ci
+  tags: packages
+
 - name: Install PostgreSQL
   apt: name={{ item }} update_cache=yes state=installed
   with_items:
-    - postgresql
-    - postgresql-contrib
+    - postgresql-9.5
+    - postgresql-contrib-9.5
     - libpq-dev
     - python-psycopg2
   tags: packages
 
 - name: Copy valid pg_hba.conf
-  template: src=pg_hba.conf.j2 dest=/etc/postgresql/9.3/main/pg_hba.conf
+  template: src=pg_hba.conf.j2 dest=/etc/postgresql/9.5/main/pg_hba.conf
 
 - name: Copy valid postgresql.conf
-  template: src=postgresql.conf.j2 dest=/etc/postgresql/9.3/main/postgresql.conf
+  template: src=postgresql.conf.j2 dest=/etc/postgresql/9.5/main/postgresql.conf
 
 - name: Ensure the PostgreSQL service is running
   service: name=postgresql state=restarted enabled=yes

--- a/provisioning/roles/db/templates/pgdg.list
+++ b/provisioning/roles/db/templates/pgdg.list
@@ -1,0 +1,1 @@
+deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main

--- a/provisioning/roles/db/templates/postgresql.conf.j2
+++ b/provisioning/roles/db/templates/postgresql.conf.j2
@@ -38,15 +38,15 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/9.3/main'		# use data in another directory
+data_directory = '/var/lib/postgresql/9.5/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/9.3/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/9.5/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/9.3/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/9.5/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/9.3-main.pid'		# write an extra PID file
+external_pid_file = '/var/run/postgresql/9.5-main.pid'		# write an extra PID file
 					# (change requires restart)
 
 


### PR DESCRIPTION
This is needed in order to make CircleCI run the tests.
Note, by itself this commit does not make CircleCI run, but together with the vault removal(which requires https://github.com/klee/klee-web/pull/69) and some other small changes the tests finally run(and fail)
