### PR TITLE
Use a RESTful API to retrieve job status

### DIFF
--- a/src/appjs/controllers.js
+++ b/src/appjs/controllers.js
@@ -107,9 +107,9 @@ controllers.controller('MainCtrl', [
             // We get a task id from submitting!
             .success(
               function(data, status, headers) {
-                channelId = data.taskId;
+                taskId = data.taskId;
                 var fetch = $interval(function () {
-                  $http.get('/jobs/notify/?channel=' + channelId).success(function(data, status, headers) {
+                  $http.get('/jobs/status/' + taskId + '/').success(function(data, status, headers) {
                     m = angular.fromJson(data);
                     var type = m['type'];
                     if(type == 'notification') {

--- a/src/klee_web/frontend/urls.py
+++ b/src/klee_web/frontend/urls.py
@@ -5,7 +5,8 @@ urlpatterns = patterns(
     url(r'^$', 'index', name='index'),
 
     # Web hooks
-    url(r'^jobs/notify/$', 'jobs_notify', name="jobs_notify"),
+    url(r'^jobs/notify/$', 'jobs_notify', name='jobs_notify'),
+    url(r'^jobs/status/([a-z0-9-]+)/$', 'jobs_status', name='jobs_status'),
 
     # User account
     url(r'^user/login/$', 'login', name='login'),

--- a/src/klee_web/frontend/views.py
+++ b/src/klee_web/frontend/views.py
@@ -39,12 +39,16 @@ def jobs_notify(request):
             task.completed_at = datetime.datetime.now()
             task.save()
             return HttpResponse('Ok!')
-    elif request.method == 'GET':
-        channel = request.GET.get('channel')
+    else:
+        return HttpResponseNotFound("This page only supports POST")
+
+
+def jobs_status(request, channel):
+    if request.method == 'GET':
         task = Task.objects.get(task_id=channel)
         return HttpResponse(task.current_output)
     else:
-        return HttpResponseNotFound("This page only supports GET and POST")
+        return HttpResponseNotFound("This page only supports GET")
 
 
 def register(request):


### PR DESCRIPTION
And also, ensure that we do not print continuously "Executing KLEE" if the build is taking longer than one second
