### PR TITLE
Resolve klee/klee_web#80 (Fix end-to-end Klee Web tests)

### DIFF
--- a/src/klee_web/tests/e2e_tests.js
+++ b/src/klee_web/tests/e2e_tests.js
@@ -27,6 +27,7 @@ it('test all', function(done1) {
             .evaluate(updateCode, function(res){}, input)
             .click("#run-klee-btn")
             .wait("#result-output")
+            .wait("code")
             // Retrieve the result and check if the expected result matches
             .evaluate(getResult, function(actual) {
                 actual.replace(/(?:\r\n|\r|\n)/g, "\n").should.match(expected)


### PR DESCRIPTION
The fix makes Nightmare wait for the tag "code" which contains the result of Klee.
