### PR TITLE
Allow the download of files in development

### DIFF
--- a/src/klee_web/frontend/urls.py
+++ b/src/klee_web/frontend/urls.py
@@ -8,6 +8,8 @@ urlpatterns = [
     url(r'^jobs/notify/$', views.jobs_notify, name='jobs_notify'),
     url(r'^jobs/status/([a-z0-9-]+)/$', views.jobs_status, name='jobs_status'),
 
+    url(r'^jobs/dl/([a-z0-9-]+)\.tar\.gz', views.jobs_dl, name='jobs_dl'),
+
     # User account
     url(r'^user/login/$', views.login, name='login'),
     url(r'^user/settings/$', views.settings, name='settings'),

--- a/src/klee_web/frontend/views.py
+++ b/src/klee_web/frontend/views.py
@@ -8,10 +8,12 @@ from django.http import HttpResponse, HttpResponseNotFound
 from django.views.decorators.csrf import csrf_exempt
 from django.core.urlresolvers import reverse
 from django.contrib import messages, auth
+from django.views.static import serve
 
 from forms import SubmitJobForm, UserCreationForm, UserChangePasswordForm
 from models import Task
 import json
+import os
 
 
 def index(request):
@@ -23,6 +25,15 @@ def store_data(task, type, data):
     d = {'type': type, 'data': data}
     task.current_output = json.dumps(d)
     task.save()
+
+
+def jobs_dl(request, file):
+    if request.method == 'GET':
+        fname = file + '.tar.gz'
+        file_path = '/tmp/' + fname
+        return serve(request, fname, os.path.dirname(file_path))
+    else:
+        return HttpResponseNotFound("This page only supports GET")
 
 
 @csrf_exempt

--- a/src/klee_web/worker/storage/dummy_storage.py
+++ b/src/klee_web/worker/storage/dummy_storage.py
@@ -1,8 +1,19 @@
+import os
+import shutil
+
+
 class DummyStorage():
     BUCKET = 'klee-output'
+    DOCKER_MOUNT_DIR = '/tmp/'
 
     def __init__(self):
         pass
 
     def store_file(self, file_path):
-        return 'File upload disabled in development'
+        # File_path is a path internal to the docker container
+        # that may or may not exist when the user wants to download it
+        base_name = os.path.basename(file_path)
+        # Copy to somewhere that does not get destroyed when docker terminates
+        final_path = os.path.join(self.DOCKER_MOUNT_DIR, base_name)
+        shutil.copy(file_path, final_path)
+        return "/jobs/dl/{0}".format(base_name)


### PR DESCRIPTION
This fixes #70 
The URL is /jobs/dl because download was too big to fit into 80 characters
