### PR TITLE
Use correct headers for the workers

### DIFF
--- a/src/klee_web/worker/processor/klee_run.py
+++ b/src/klee_web/worker/processor/klee_run.py
@@ -53,7 +53,8 @@ class KleeRunProcessor(BaseProcessor):
         code_file = self.runner.DOCKER_CODE_FILE
         object_file = self.runner.DOCKER_OBJECT_FILE
         llvm_command = ['/usr/bin/clang-3.4',
-                        '-I', '/src/klee/include', '-emit-llvm', '-c', '-g',
+                        '-I', '/home/klee/klee_src/include/klee',
+                        '-emit-llvm', '-c', '-g',
                         code_file, '-o', object_file]
         self.runner.run_with_docker(llvm_command)
 

--- a/src/klee_web/worker/tests/fixtures/invalid_syntax/expected.stdout
+++ b/src/klee_web/worker/tests/fixtures/invalid_syntax/expected.stdout
@@ -1,4 +1,4 @@
-Error running /usr/bin/clang-3.4 -I /src/klee/include -emit-llvm -c -g /tmp/code/code.c -o /tmp/code/code.o:
+Error running /usr/bin/clang-3.4 -I /home/klee/klee_src/include/klee -emit-llvm -c -g /tmp/code/code.c -o /tmp/code/code.o:
 /tmp/code/code.c:4:9: warning: missing terminating '"' character \[-Winvalid-pp-token\]
         printf\("Hello world\\n\);
                \^


### PR DESCRIPTION
This allows us to include <klee.h> and other headers in examples or files uploaded by the users
