### PR TITLE
Frontend: Fix scrollbar overlaying dropdowns.

### DIFF
--- a/src/sass/components/_editor.scss
+++ b/src/sass/components/_editor.scss
@@ -182,6 +182,7 @@
 	.CodeMirror {
 		padding-top: 10px;
 		height: calc(100% - #{$topbar-height});
+		z-index: 0;
 
 		.CodeMirror-gutters {
 			// background-color: $line-nums-bg-color;


### PR DESCRIPTION
Small UI fix to prevent the editor scrollbar from overlaying the option dropdown menus.
