### PR TITLE
Make sure that acl package is available

### DIFF
--- a/provisioning/roles/db/tasks/main.yml
+++ b/provisioning/roles/db/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Make sure acl is installed
+  apt: name=acl update_cache=yes state=latest
+
 - name: "Add postgresql repo"
   template: src=pgdg.list dest=/etc/apt/sources.list.d/pgdg.list
   when: not ci


### PR DESCRIPTION
For some ubuntu VMs (probably old versions) acl package is missing. We might also want to restrict Vagrant VM version with `config.vm.box_version`
