### PR TITLE
Ensure that the vagrant box is reasonably up-to-date

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/trusty64"
+  config.vm.box_version = ">= 20160826.0.1"
 
   if Vagrant.has_plugin?("vagrant-cachier")
     # Configure cached packages to be shared between instances of the same base box.


### PR DESCRIPTION
Set the minimum version to the latest as of today (31/08/2016)
