### PR TITLE
Klee_Web: Django: migrate to python-social-auth

### DIFF
--- a/src/klee_web/requirements.txt
+++ b/src/klee_web/requirements.txt
@@ -12,4 +12,5 @@ djangorestframework==3.4.1
 drf-nested-routers==0.11.1
 djangorestframework-camel-case
 geoip2
+social-auth-app-django
 django-rest-framework-social-oauth2

--- a/src/klee_web/settings.py
+++ b/src/klee_web/settings.py
@@ -79,7 +79,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework_nested',
     'oauth2_provider',
-    'social.apps.django_app.default',
+    'social_django',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -123,9 +123,9 @@ USE_I18N = True
 USE_L10N = True
 
 AUTHENTICATION_BACKENDS = (
-    'social.backends.facebook.FacebookOAuth2',
-    'social.backends.google.GoogleOAuth2',
-    'social.backends.github.GithubOAuth2',
+    'social_core.backends.facebook.FacebookOAuth2',
+    'social_core.backends.google.GoogleOAuth2',
+    'social_core.backends.github.GithubOAuth2',
     'django.contrib.auth.backends.ModelBackend',
 )
 


### PR DESCRIPTION
As https://github.com/omab/python-social-auth got deprecated, we are migrating to https://github.com/python-social-auth/social-app-django
