### PR TITLE
Changed tag latest to using a specfic digest.

### DIFF
--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -10,7 +10,8 @@ db_host: "{{ postgres_container }}"
 db_port: 5432
 db_name: klee_web
 db_user: klee_web
-klee_version: latest
+# Expected format: ":tag" or "@sha256:..."
+klee_version: "@sha256:b38cc919a569319ad58bd9ab39e0e657b2b30bb1a2ea8e2df8cef7cde36ff5f6"
 
 # Paths
 src_dir: /kleeweb_src

--- a/provisioning/roles/worker/tasks/build.yml
+++ b/provisioning/roles/worker/tasks/build.yml
@@ -10,13 +10,13 @@
 
 - name: Get KLEE image from Docker Hub (this may take a while...) version {{ klee_version }}
   docker_image:
-    name: klee/klee
-    tag: "{{ klee_version }}"
+    name: "klee/klee{{ klee_version }}"
     source: pull
+  register: klee_image
 
 - name: Pin the above KLEE version as latest.
   docker_image:
-    name: "klee/klee:{{ klee_version }}"
+    name: "{{ klee_image.image.Id }}"
     repository: klee/klee:latest
     force_tag: yes
     source: local


### PR DESCRIPTION
Use specific digest when retrieving KLEE image.
Result of retrieving image is used to tag as latest on local.