### PR TITLE
Added runner and e2e tests for stats and coverage functionalities.

### DIFF
--- a/src/e2e/test_files/e2e.test.js
+++ b/src/e2e/test_files/e2e.test.js
@@ -69,28 +69,92 @@ describe("New Projects", () => {
 });
 
 describe("Klee Testcases", () => {
-  it(
-      "tests that testcases window appears and is index-able",
-      async () => {
-          await page.goto("http://" + WEBPAGE + "/user/logout");
-          await page.waitForSelector("#run-klee-btn");
-          await page.waitForSelector('[ng-repeat="file in files"]');
-          await page.click('[ng-repeat="file in files"]'); // select first file ... use page.select instead?
-          await page.click("#run-klee-btn");
-          await page.waitForSelector("#result-output"); // need to wait for KLEE to finish output
-          await page.waitForSelector("#klee-testcases-btn");
-          await page.click('#klee-testcases-btn');
-          await page.waitForSelector("#klee-testcases-pagination");
+  it("tests that testcases window appears and is index-able", async () => {
+    await page.goto("http://" + WEBPAGE + "/user/logout");
+    await page.waitForSelector("#run-klee-btn");
+    await page.waitForSelector('[ng-repeat="file in files"]');
+    await page.click('[ng-repeat="file in files"]'); // select first file ... use page.select instead?
+    await page.click("#run-klee-btn");
+    await page.waitForSelector("#result-output"); // need to wait for KLEE to finish output
+    await page.waitForSelector("#klee-testcases-btn");
+    await page.click('#klee-testcases-btn');
+    await page.waitForSelector("#klee-testcases-pagination");
 
-          // Tests that there are 3 testcases
-          const numTestcases =
-              (await page.$$("#klee-testcases-pagination li")).length;
-          const navButtons = 4;
-          await expect(numTestcases).toBe(navButtons + 3);
+    // Tests that there are 3 testcases
+    const numTestcases =
+        (await page.$$("#klee-testcases-pagination li")).length;
+    const navButtons = 4;
+    await expect(numTestcases).toBe(navButtons + 3);
 
-          // Tests that there are 1 mem objs
-          const numMemObjs =
-              (await page.$$(".klee-testcases tbody tr")).length;
-          await expect(numMemObjs).toBe(1);
-      })
-})
+    // Tests that there are 1 mem objs
+    const numMemObjs =
+        (await page.$$(".klee-testcases tbody tr")).length;
+    await expect(numMemObjs).toBe(1);
+    });
+});
+
+describe("Stats", () => {
+  it("tests that stats window works", async () => {
+    await page.goto("http://" + WEBPAGE + "/user/logout");
+    await page.waitForSelector("#run-klee-btn");
+    await page.waitForSelector('[ng-repeat="file in files"]');
+    await page.click('[ng-repeat="file in files"]'); // select first file ... use page.select instead?
+    await page.click("#run-klee-btn");
+    await page.waitForSelector("#result-output");
+
+    const text = await page.evaluate(
+      () => document.querySelector("#result-output").innerText
+    );
+    const stdoutInstr = Number(
+        text.match(/(?<=total instructions = )\d+/g)[0]
+    );
+
+    await page.waitForSelector("#stats-btn");
+    await page.click("#stats-btn");
+
+    // Tests that number of stats rows is 6
+    const statRows = await page.$$(".klee-output tbody tr");
+    await expect(statRows.length).toBe(6);
+
+    // Tests number of instrs matches is 33
+    const instrStat = await statRows[0].$$eval("td", tds => tds.map(
+        td => td.textContent
+    ));
+    await expect(Number(instrStat[1])).toBe(stdoutInstr);
+  });
+});
+
+describe("Coverage", () => {
+  it("tests that coverage window works", async () => {
+    await page.goto("http://" + WEBPAGE + "/user/logout");
+    await page.waitForSelector("#run-klee-btn");
+    await page.waitForSelector('[ng-repeat="file in files"]');
+    await page.click('[ng-repeat="file in files"]'); // select first file ... use page.select instead?
+    await page.waitForSelector(".coverage-btn");
+    await page.click(".coverage-btn");
+    await page.click("#run-klee-btn");
+    await page.waitForSelector("#res-cov-btn");
+    await page.click("#res-cov-btn");
+
+    // Tests coverage text matches
+    const covText = await page.$eval(
+        ".klee-coverage pre",
+        pre => pre.textContent
+    );
+    await expect(covText).toBe(" 100% of lines covered.");
+
+    // Tests that top comment is not colored
+    const commentText = await page.$eval(
+        ".line-null .cm-comment",
+        span => span.textContent
+    );
+    await expect(commentText).toBe("/*");
+
+    // Tests that first hit should be get_sign function
+    const firstHitText = await page.$eval(
+        ".line-hit .cm-variable",
+        span => span.textContent
+    );
+    await expect(firstHitText).toBe("get_sign");
+  });
+});

--- a/src/klee_web/frontend/templates/frontend/index.html
+++ b/src/klee_web/frontend/templates/frontend/index.html
@@ -344,12 +344,14 @@
                                     <a href="#"
                                        ng-click="setTab('output')">Output</a>
                                 </li>
-                                <li ng-class="{active: tabs.stats.active}">
+                                <li ng-class="{active: tabs.stats.active}"
+                                    id="stats-btn">
                                     <a href="#"
                                        ng-click="setTab('stats')">Stats</a>
                                 </li>
                                 <li ng-class="{active: tabs.coverage.active}"
-                                    ng-if="result.coverage">
+                                    ng-if="result.coverage"
+                                    id="res-cov-btn">
                                     <a href="#"
                                        ng-click="setTab('coverage')">Coverage</a>
                                 </li>

--- a/src/klee_web/worker/processor/stats.py
+++ b/src/klee_web/worker/processor/stats.py
@@ -25,7 +25,7 @@ class StatsProcessor(BaseProcessor):
         for row in stats_csv:
             if first:
                 combined = [(key, []) for key in row]
-                first = True
+                first = False
             [combined[ind][1].append(item[1]) for ind, item
              in enumerate(row.items())]
 

--- a/src/klee_web/worker/tests/test_cov_runner.py
+++ b/src/klee_web/worker/tests/test_cov_runner.py
@@ -1,0 +1,93 @@
+import re
+import os
+import unittest
+import codecs
+
+from worker.runner import WorkerRunner
+from worker.processor.klee_run import KleeRunProcessor
+from worker.processor.coverage import CoverageProcessor
+from worker.exceptions import KleeRunFailure
+
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+FIXTURE_DIR = os.path.join(BASE_DIR, 'fixtures')
+
+
+class TestWorkerRunner(unittest.TestCase):
+    def setUp(self):
+        self.runner = WorkerRunner(
+            'test',
+            pipeline=[KleeRunProcessor, CoverageProcessor]
+        )
+        self.runner.__enter__()
+
+    def tearDown(self):
+        self.runner.__exit__(None, None, None)
+
+    def run_klee_test(self, fixture_name, run_configuration=None,
+                      expect_failure=False):
+        if not run_configuration:
+            run_configuration = {}
+
+        test_fixtures = os.path.join(FIXTURE_DIR, fixture_name)
+
+        with codecs.open(os.path.join(test_fixtures, 'input.c'),
+                         encoding='utf-8') as f:
+            code = f.read()
+
+        with codecs.open(os.path.join(test_fixtures, 'expected.stdout'),
+                         encoding='utf-8') as f:
+            expected_out = f.read()
+
+        flags = re.M | re.DOTALL | re.UNICODE
+        expected_regex = re.compile(u"{}$".format(expected_out), flags)
+        if expect_failure:
+            self.assertRaisesRegex(KleeRunFailure, expected_regex,
+                                   self.runner.execute_pipeline, code,
+                                   run_configuration)
+        else:
+            result = self.runner.execute_pipeline(code, run_configuration)
+            # stdout = result['klee_run']['output']
+            cov = result['coverage']
+            # Assert cov list has only 1 element for 1 code file
+            self.assertEqual(len(cov), 1)
+            cov = cov[0]
+            # Assert correct keys for cov object
+            self.assertIn('file', cov)
+            self.assertIn('lines', cov)
+            # Assert number of lines in cov equal num of code lines
+            num_lines = len(code.splitlines())
+            self.assertEqual(len(cov['lines']), num_lines)
+            # Assert line has the correct keys and in ascending order
+            prev_line = 0
+            for line in cov['lines']:
+                self.assertIn('line', line)
+                self.assertIn('hit', line)
+                self.assertTrue(prev_line <= line['line'])
+                prev_line = line['line']
+
+    def test_simple_run(self):
+        self.run_klee_test('simple', {'coverage_enabled': True})
+
+    def test_simple_unicode_run(self):
+        self.run_klee_test('simple_unicode', {'coverage_enabled': True})
+
+    def test_symargs(self):
+        self.run_klee_test('symargs', {
+            'sym_args': {
+                'range': [1, 1],
+                'size': 1
+            },
+            'coverage_enabled': True
+        })
+
+    def test_symin(self):
+        self.run_klee_test('symin', {
+            'sym_in': {
+                'size': 1
+            },
+            'coverage_enabled': True
+        })
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/klee_web/worker/tests/test_stats_runner.py
+++ b/src/klee_web/worker/tests/test_stats_runner.py
@@ -1,0 +1,87 @@
+import re
+import os
+import unittest
+import codecs
+
+from worker.runner import WorkerRunner
+from worker.processor.klee_run import KleeRunProcessor
+from worker.processor.stats import StatsProcessor
+from worker.exceptions import KleeRunFailure
+
+
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+FIXTURE_DIR = os.path.join(BASE_DIR, 'fixtures')
+
+
+class TestWorkerRunner(unittest.TestCase):
+    def setUp(self):
+        self.runner = WorkerRunner(
+            'test',
+            pipeline=[KleeRunProcessor, StatsProcessor]
+        )
+        self.runner.__enter__()
+
+    def tearDown(self):
+        self.runner.__exit__(None, None, None)
+
+    def run_klee_test(self, fixture_name, run_configuration=None,
+                      expect_failure=False):
+        if not run_configuration:
+            run_configuration = {}
+
+        test_fixtures = os.path.join(FIXTURE_DIR, fixture_name)
+
+        with codecs.open(os.path.join(test_fixtures, 'input.c'),
+                         encoding='utf-8') as f:
+            code = f.read()
+
+        with codecs.open(os.path.join(test_fixtures, 'expected.stdout'),
+                         encoding='utf-8') as f:
+            expected_out = f.read()
+
+        flags = re.M | re.DOTALL | re.UNICODE
+        expected_regex = re.compile(u"{}$".format(expected_out), flags)
+        if expect_failure:
+            self.assertRaisesRegex(KleeRunFailure, expected_regex,
+                                   self.runner.execute_pipeline, code,
+                                   run_configuration)
+        else:
+            result = self.runner.execute_pipeline(code, run_configuration)
+            stdout = result['klee_run']['output']
+            stats = result['stats']
+            # Assert stats list has 6 rows
+            self.assertEqual(len(stats), 6)
+            # Assert only 1 stat returned for 1 file
+            for stat in stats:
+                self.assertEqual(len(stat[1]), 1)
+            # Assert instr equal to stdout
+            expected_instr = int(re.search(
+                r'(?<=total instructions = )\d+',
+                stdout
+            ).group())
+            self.assertEqual(int(stats[0][1][0]), expected_instr)
+
+    def test_simple_run(self):
+        self.run_klee_test('simple')
+
+    def test_simple_unicode_run(self):
+        self.run_klee_test('simple_unicode')
+
+    def test_symargs(self):
+        self.run_klee_test('symargs', {
+            'sym_args': {
+                'range': [1, 1],
+                'size': 1
+            }
+        })
+
+    def test_symin(self):
+        self.run_klee_test('symin', {
+            'sym_in': {
+                'size': 1
+            }
+        })
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added e2e tests that tests:

- stats shows 6 rows of klee run stats
- stats shows the same instr count as stdout
- cov shows coverage percentage
- cov colours the correct lines

Added runner tests that tests:

- stats returns 6 rows of klee run stats
- stats only return 1 stat since only 1 klee-out dir
- stats return the same instr as stdout
- cov returns only 1 coverage stat for 1 code file
- cov returns the correct JSON/dict format
- cov returns the same number of cov lines as code lines
- cov returns lines in ascending order